### PR TITLE
Add version requirement according API requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ SkyWalking Kong agent built on [SkyWalking Nginx Lua agent](https://github.com/a
 
 ## Usage
 
+Kong 2.2+ required.
+
 1. Install the plugin in Kong:
 
 Install kong-plugin-skywalking using `luarocks`:


### PR DESCRIPTION
Close https://github.com/apache/skywalking/issues/7308

We require Kong's `get_hostname` API for the remote hostname, which started at Kong 2.2+